### PR TITLE
added socket for app support

### DIFF
--- a/drivers/DMamplifier/device.js
+++ b/drivers/DMamplifier/device.js
@@ -19,8 +19,6 @@ var receivedData = "";
 // MVMax is the maximum volume number (e.g. 70)
 var MVMax = 70;
 
-var connectionTimeout = false;
-
 // The Denon/Marantz IP network interface always uses port 23, which is known as the telnet port.
 var telnetPort = 23;
 // All known inputs for supported Denon/Marantz AV receivers and a more friendly name to use.
@@ -679,7 +677,7 @@ class DMDevice extends Homey.Device {
                     server = new net.createServer(function(socket) {
                         device.log("external client connected");
 
-                        socket.on('error', console.log);
+                        socket.on('error', device.log);
 
                         socket.pipe(client, { end: false });
                         client.pipe(socket, { end: false });
@@ -687,7 +685,7 @@ class DMDevice extends Homey.Device {
                     server.listen(EXT_CONN_PORT);
                 } );
 
-                client.on('end', () => {
+                client.on('end', function {
                     device.log("DISCONNECTING WITH AVR");
                     server.close();
                 });


### PR DESCRIPTION
Currently it's not possible to use the Android or Iphone app along with the Homey app because the Marantz device only allows one tcp connection to the telnet port. When the homey app starts it immediately connects to the marantz device and locks out any other device that wants to connect to that particular port. 

To fix this problem I've added a tcp server to the homey app which socket is piped to the avr tcp socket. In this way you're still able to use the app. 

The only thing you have to change is setting the ip address and port in the Android or Iphone app to

<< IP address >>:5000 

Example: 192.168.0.58:5000

